### PR TITLE
Allow malformed properties (#21)

### DIFF
--- a/src/main/java/net/frozenblock/lib/item/api/ItemBlockStateTagUtils.java
+++ b/src/main/java/net/frozenblock/lib/item/api/ItemBlockStateTagUtils.java
@@ -32,7 +32,7 @@ public class ItemBlockStateTagUtils {
 			if (stateTag != null) {
 				String stringValue = property.getName();
 				if (stateTag.contains(stringValue)) {
-					return property.getValue(stateTag.getString(stringValue)).get();
+					return property.getValue(stateTag.getString(stringValue)).orElse(defaultValue);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes #21 by replacing the `Optional.get()` call with `.orElse(defaultValue)`