### PR TITLE
fix (jitpack) build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
 }
 
 plugins {
-	id("fabric-loom") version("+")
+	id("fabric-loom") version("1.6-SNAPSHOT")
 	id("org.ajoberstar.grgit") version("+")
 	id("org.quiltmc.gradle.licenser") version("+")
 	id("com.modrinth.minotaur") version("+")
@@ -443,8 +443,6 @@ publishing {
                 } catch (ignored: FileNotFoundException) {
                     // No existing version was published, so we can publish
                 }
-            } else {
-                publish = false
             }
         } catch (e: Exception) {
             publish = false

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,3 @@
 before_install:
-  - wget https://github.com/sormuras/bach/raw/releases/11/install-jdk.sh
-  - source install-jdk.sh --feature 21
-
-jdk:
-  - openjdk21
+  - sdk install java 21.0.3-tem
+  - sdk use java 21.0.3-tem


### PR DESCRIPTION
For context, I wanted to depend on FrozenLib via jitpack: https://github.com/RandomMcSomethin/fallingleaves/issues/65#issuecomment-2132703091

The build is [currently broken](https://github.com/Fourmisain/FrozenLib/actions/runs/9242368279/job/25425096853) in general due to it using Loom 1.7.0-alpha.4.
(It's apparently playing bad with with the layered mappings, erroring on remapping Cloth Config.)

The jitpack build fails due to the [outdated install script](https://jitpack.io/com/github/FrozenBlock/FrozenLib/1.7.2-mc1.20.6/build.log) and it [not being able to publish to maven local](https://jitpack.io/com/github/Fourmisain/FrozenLib/1c6c4c8ce7/build.log), all very simple fixes.

Tested working via
```
    modCompileOnly("com.github.Fourmisain:FrozenLib:jitpack-SNAPSHOT") {
        exclude(group: "com.github.glitchfiend")
    }
```
(Maybe that should be part of the documentation.)

**edit**:
Apparently jitpack currently runs into read timeouts, maybe give it an hour or two.
**edit3**: Read timeouts are gone, build should now work.

**edit2**:
I'm an idiot, I completely forgot about [Modrinth Maven](https://support.modrinth.com/en/articles/8801191-modrinth-maven).
`modImplementation "maven.modrinth:frozenlib:1.7.2-mc1.20.6"` and there you go, it just works.
(Maybe _that_ should be part of the documentation.)

You decide whether you still want to pull this. Shouldn't hurt, but jitpack was never the most reliable to begin with.