### PR TITLE
Fix client hang on shutdown from non-daemon thread pools

### DIFF
--- a/common/src/main/java/net/frozenblock/lib/cape/api/CapeUtil.java
+++ b/common/src/main/java/net/frozenblock/lib/cape/api/CapeUtil.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import net.frozenblock.lib.FrozenLibConstants;
 import net.frozenblock.lib.cape.client.api.ClientCapeUtil;
 import net.frozenblock.lib.cape.impl.Cape;
@@ -46,6 +45,7 @@ import net.frozenblock.lib.platform.ModLoader;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Util;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -125,7 +125,7 @@ public class CapeUtil {
 				} catch (IOException ignored) {}
 				return Optional.empty();
 			},
-			Executors.newCachedThreadPool()
+			Util.nonCriticalIoPool().forName("registerCapesFromURL")
 		).whenComplete((value, throwable) -> {
 			value.ifPresent(string -> CAPE_REPOS.add((String) string));
 		});

--- a/common/src/main/java/net/frozenblock/lib/platform/api/registry/DeferredActivity.java
+++ b/common/src/main/java/net/frozenblock/lib/platform/api/registry/DeferredActivity.java
@@ -20,7 +20,6 @@ package net.frozenblock.lib.platform.api.registry;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.schedule.Activity;
 
 public class DeferredActivity implements DeferredHolder<Activity, Activity> {

--- a/common/src/main/java/net/frozenblock/lib/platform/api/registry/DeferredSimpleParticleType.java
+++ b/common/src/main/java/net/frozenblock/lib/platform/api/registry/DeferredSimpleParticleType.java
@@ -18,7 +18,6 @@
 package net.frozenblock.lib.platform.api.registry;
 
 import net.minecraft.core.Holder;
-import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.resources.Identifier;

--- a/common/src/main/java/net/frozenblock/lib/resource/client/api/pack/ModResourcePackApi.java
+++ b/common/src/main/java/net/frozenblock/lib/resource/client/api/pack/ModResourcePackApi.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.zip.ZipFile;
@@ -58,6 +57,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.StringRepresentable;
+import net.minecraft.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -230,7 +230,7 @@ public final class ModResourcePackApi {
 					return failToast;
 				}
 			},
-			Executors.newCachedThreadPool()
+			Util.nonCriticalIoPool().forName("downloadModResourcePack")
 		).whenComplete((value, throwable) -> {
 			value.ifPresent(failToast -> ((ToastInfo)failToast).addToast());
 		});


### PR DESCRIPTION
Fixes #79

## Problem

Quitting the game leaves the process alive until vanilla's
`ClientShutdownWatchdog` times out and dumps a crash report. The report is
misleading — there's no exception, just a `java.lang.Error: Watchdog (Client
shutdown from post-main)` about 15 seconds after `Stopping!`, with the thread
dump showing nothing obviously wrong.

## Cause

Two API paths call `Executors.newCachedThreadPool()`:

- `CapeUtil.registerCapesFromURL`
- `ModResourcePackApi` pack downloading

`newCachedThreadPool()` uses `Executors.defaultThreadFactory()`, which creates
**non-daemon** threads, and keeps each idle worker alive for a 60 second
keepalive after its task completes. Non-daemon threads block JVM exit, so if
you quit within that window the process just sits there until the watchdog
fires.

It also allocates an entirely new pool per call rather than reusing one.

## Fix

Both now use `Util.nonCriticalIoPool()` — vanilla's shared, daemon-backed pool,
already used elsewhere in this repo (`ServerTextureDownloader`). `.forName(...)`
tags the worker so it stays readable in thread dumps.

```diff
-			Executors.newCachedThreadPool()
+			Util.nonCriticalIoPool().forName("registerCapesFromURL")